### PR TITLE
Add Disabled Selectors and Searchable Selectors to the Example App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an animated GIF showcasing the example app on README ([#23](https://github.com/rhventures/react-native-dropdown-selector/pull/23)).
 - Selectors are now able to be disabled via providing a boolean prop ([#25](https://github.com/rhventures/react-native-dropdown-selector/pull/25)).
 - Selectors are now able to have a search bar via providing a boolean prop ([#27](https://github.com/rhventures/react-native-dropdown-selector/pull/27)).
-- A plain multi selector that toggles the `disabled` and `searchable` prop in all other selectors ([#28](https://github.com/rhventures/react-native-dropdown-selector/pull/28)).
+- Add a plain multi selector to example app that toggles the `disabled` and `searchable` prop in all other selectors ([#28](https://github.com/rhventures/react-native-dropdown-selector/pull/28)).
 
 ### Changed
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,9 +42,9 @@ export interface MultiSelectProperties {
   data: Data[];
   onSelect: (e: Data[]) => void;
   defaultValue?: Data[];
+  disabled?: boolean;
   listHeight?: number;
   placeholderText?: string | React.JSX.Element;
-  disabled?: boolean;
   searchable?: boolean;
   boxStyle?: ViewStyle;
   boxTextStyle?: TextStyle;
@@ -62,9 +62,9 @@ export interface SelectProperties {
   data: Data[];
   onSelect: (e: Data) => void;
   defaultValue?: Data;
+  disabled?: boolean;
   listHeight?: number;
   placeholderText?: string | React.JSX.Element;
-  disabled?: boolean;
   searchable?: boolean;
   boxStyle?: ViewStyle;
   boxTextStyle?: TextStyle;


### PR DESCRIPTION
### Previous Issue
The example app wasn't testing `disabled` and `searchable`
<br />
### Purpose of this PR
Adding a multi selector to modify other selectors with the `disabled` and `searchable` options.

Branched from #27.
<br />
### Testing
Manual UI testing was involved, including:
- Picking `disabled`
- Picking `searchable`

### Issues
When the clear button on the new multi selector is clicked when the `disabled` and/or the `searchable` option is enabled, other selectors are not affect by this change, indicating that this is an edge case not covered by the clear button. Another PR should be made to address and fix this.