### PR TITLE
Add Dynamic Theme Support and Reduce Style Duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selectors are now able to have a search bar via providing a boolean prop ([#27](https://github.com/rhventures/react-native-dropdown-selector/pull/27)).
 - Add a plain multi selector to example app that toggles the `disabled` and `searchable` prop in all other selectors ([#28](https://github.com/rhventures/react-native-dropdown-selector/pull/28)).
 - Add pre-commit hooks to ensure code quality ([#53](https://github.com/rhventures/react-native-dropdown-selector/pull/53)).
+- Added a new string prop `theme` to allow explicit customization of `Select` and `MultiSelect` components. Options are `system`, `light`, and `dark` ([#55](https://github.com/rhventures/react-native-dropdown-selector/pull/55)).
 
 ### Changed
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text, View, Button } from 'react-native';
 import { MultiSelect, Select, type Data } from '@rose-hulman/react-native-dropdown-selector';
 
 const data: Data[] = [
@@ -22,6 +22,7 @@ function App(): React.JSX.Element {
   const [item, setItem] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
   const [searchable, setSearchable] = React.useState(false);
+  const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
   const onDataSelect = (datum: Data) =>
     setItem(datum.label);
   const onMultiDataSelect = (data: Data[]) =>
@@ -34,11 +35,18 @@ function App(): React.JSX.Element {
       <View style={{ height: 40 }} />
       <ScrollView style={{ paddingHorizontal: 8 }}>
         <View style={{ height: 40 }} />
+        <Text style={{ fontSize: 18, fontWeight: 'bold', textAlign: 'center' }}>Theme Selector</Text>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginVertical: 16 }}>
+          <Button title="Light Theme" onPress={() => setTheme('light')} />
+          <Button title="Dark Theme" onPress={() => setTheme('dark')} />
+          <Button title="System Theme" onPress={() => setTheme('system')} />
+        </View>
         <Select
           data={data}
           onSelect={onDataSelect}
           disabled={disabled}
           searchable={searchable}
+          theme={theme}
         />
         <Text>Selected: {item || 'None'} (scroll down)</Text>
         <View style={{ height: 500 }} />
@@ -57,6 +65,7 @@ function App(): React.JSX.Element {
           disabled={disabled}
           searchable={searchable}
           placeholderText="Select an item"
+          theme={theme}
           boxStyle={{
             alignSelf: 'center',
             width: 200,
@@ -67,6 +76,7 @@ function App(): React.JSX.Element {
           onSelect={onMultiDataSelect}
           disabled={disabled}
           searchable={searchable}
+          theme={theme}
         />
         <View style={{ height: 400 }}/>
         <Text>Single Selects:</Text>
@@ -77,6 +87,7 @@ function App(): React.JSX.Element {
               onSelect={onDataSelect}
               disabled={disabled}
               searchable={searchable}
+              theme={theme}
             />
           </View>
           <View style={{ flex: 1 }}>
@@ -85,6 +96,7 @@ function App(): React.JSX.Element {
               onSelect={onDataSelect}
               disabled={disabled}
               searchable={searchable}
+              theme={theme}
             />
           </View>
           <View style={{ flex: 1 }}>
@@ -93,6 +105,7 @@ function App(): React.JSX.Element {
               onSelect={onDataSelect}
               disabled={disabled}
               searchable={searchable}
+              theme={theme}
             />
           </View>
         </View>
@@ -105,6 +118,7 @@ function App(): React.JSX.Element {
                 onSelect={onMultiDataSelect}
                 disabled={disabled}
                 searchable={searchable}
+                theme={theme}
               />
             </View>
             <View style={{ flex: 1 }}>
@@ -113,6 +127,7 @@ function App(): React.JSX.Element {
                 onSelect={onMultiDataSelect}
                 disabled={disabled}
                 searchable={searchable}
+                theme={theme}
               />
             </View>
             <View style={{ flex: 1 }}>
@@ -121,6 +136,7 @@ function App(): React.JSX.Element {
                 onSelect={onMultiDataSelect}
                 disabled={disabled}
                 searchable={searchable}
+                theme={theme}
               />
             </View>
           </View>
@@ -142,7 +158,7 @@ function App(): React.JSX.Element {
               }
             }}
             placeholderText='Selector Settings'
-
+            theme={theme}
           />
         </View>
         <Text>Styled Single Select:</Text>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Text, View, Button } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
 import { MultiSelect, Select, type Data } from '@rose-hulman/react-native-dropdown-selector';
 
 const data: Data[] = [
@@ -18,6 +18,12 @@ const options: Data[] = [
   { label: 'Searchable' },
 ];
 
+const themes: Data[] = [
+  { label: 'light' },
+  { label: 'dark' },
+  { label: 'system' },
+];
+
 function App(): React.JSX.Element {
   const [item, setItem] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
@@ -29,18 +35,14 @@ function App(): React.JSX.Element {
     setItem(data.map((datum: Data) =>
       datum.label
     ).join(", "));
+  const onThemeSelect = (datum: Data) =>
+    setTheme(datum.label as 'light' | 'dark' | 'system');
 
   return (
     <>
       <View style={{ height: 40 }} />
       <ScrollView style={{ paddingHorizontal: 8 }}>
         <View style={{ height: 40 }} />
-        <Text style={{ fontSize: 18, fontWeight: 'bold', textAlign: 'center' }}>Theme Selector</Text>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginVertical: 16 }}>
-          <Button title="Light Theme" onPress={() => setTheme('light')} />
-          <Button title="Dark Theme" onPress={() => setTheme('dark')} />
-          <Button title="System Theme" onPress={() => setTheme('system')} />
-        </View>
         <Select
           data={data}
           onSelect={onDataSelect}
@@ -110,7 +112,7 @@ function App(): React.JSX.Element {
           </View>
         </View>
         <Text>Multi Selects:</Text>
-        <View style={{ height: 400 }}>
+        <View style={{ height: 350 }}>
           <View style={{ flexDirection: 'row' }}>
             <View style={{ flex: 1 }}>
               <MultiSelect
@@ -160,6 +162,19 @@ function App(): React.JSX.Element {
             placeholderText='Selector Settings'
             theme={theme}
           />
+        </View>
+        <View style={{ height: 200 }}>
+          <Select
+            data={themes}
+            onSelect={onThemeSelect}
+            disabled={disabled}
+            searchable={searchable}
+            placeholderText={`Select a theme`}
+            theme={theme}
+          />
+          <Text style={{ textAlign: 'center'}}>
+            Select a theme to see all the dropdowns change! Current theme is "{theme}"
+          </Text>
         </View>
         <Text>Styled Single Select:</Text>
         <Select

--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState } from 'react';
-import { Text, TouchableOpacity, View, useColorScheme } from 'react-native';
-import styles from '../styles';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useThemeStyles } from '../styles';
 import type { Data, SelectorRect, MultiSelectProperties } from '../types';
 import SelectionList from './SelectionList';
 
 /* Renders a multi-selector component. Takes in props defined in the MultiSelectProperties type. */
-const MultiSelect = (props: MultiSelectProperties): React.JSX.Element => {
-  const style = styles[useColorScheme() === 'dark' ? 1 : 0];
+const MultiSelect = (props: MultiSelectProperties & { theme?: 'dark' | 'light' | 'system' }): React.JSX.Element => {
+  const style = useThemeStyles(props.theme ?? 'system');
   const ref = useRef<TouchableOpacity>(null);
   const [listDisplay, setListDisplay] = useState<boolean>(false);
   const [refRect, setRefRect] = useState<SelectorRect>({
@@ -107,6 +107,7 @@ const MultiSelect = (props: MultiSelectProperties): React.JSX.Element => {
         searchable={!!props.searchable}
         hide={() => setListDisplay(false)}
         selectorRect={refRect}
+        theme={props.theme}
       />
     </View>
   );

--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -5,7 +5,7 @@ import type { Data, SelectorRect, MultiSelectProperties } from '../types';
 import SelectionList from './SelectionList';
 
 /* Renders a multi-selector component. Takes in props defined in the MultiSelectProperties type. */
-const MultiSelect = (props: MultiSelectProperties & { theme?: 'dark' | 'light' | 'system' }): React.JSX.Element => {
+const MultiSelect = (props: MultiSelectProperties): React.JSX.Element => {
   const style = useThemeStyles(props.theme ?? 'system');
   const ref = useRef<TouchableOpacity>(null);
   const [listDisplay, setListDisplay] = useState<boolean>(false);

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState } from 'react';
-import { Text, TouchableOpacity, View, useColorScheme } from 'react-native';
-import styles from '../styles';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useThemeStyles } from '../styles';
 import type { Data, SelectorRect, SelectProperties } from '../types';
 import SelectionList from './SelectionList';
 
 /* Renders a selector component. Takes in props defined in the SelectProperties type. */
 const Select = (props: SelectProperties): React.JSX.Element => {
-  const style = styles[useColorScheme() === 'dark' ? 1 : 0];
+  const style = useThemeStyles(props.theme ?? 'system');
   const ref = useRef<TouchableOpacity>(null);
   const [listDisplay, setListDisplay] = useState<boolean>(false);
   const [refRect, setRefRect] = useState<SelectorRect>({
@@ -82,6 +82,7 @@ const Select = (props: SelectProperties): React.JSX.Element => {
         searchable={!!props.searchable}
         hide={() => setListDisplay(false)}
         selectorRect={refRect}
+        theme={props.theme}
       />
     </View>
   );

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -7,15 +7,14 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  View,
-  useColorScheme
+  View
 } from 'react-native';
-import styles from '../styles';
+import { useThemeStyles } from '../styles';
 import type { Data, ListProperties } from '../types';
 
 /* Renders a modal with a list of selectable items. Takes in props defined in the ListProperties type. */
-const SelectionList = (props: ListProperties): React.JSX.Element => {
-  const style = styles[useColorScheme() === 'dark' ? 1 : 0];
+const SelectionList = (props: ListProperties & { theme?: 'dark' | 'light' | 'system' }): React.JSX.Element => {
+  const style = useThemeStyles(props.theme ?? 'system');
   const windowWidth = Dimensions.get('window').width;
   const windowHeight = Dimensions.get('window').height;
   const [keyboardHeight, setKeyboardHeight] = useState<number>(0);
@@ -93,6 +92,7 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
             <TextInput
               placeholder='Search'
               style={[style.searchBox, props.styles.searchBox]}
+              placeholderTextColor={style.searchBox.color}
               onChangeText={(input: string) => 
                 setEntries(props.data.filter((data: Data) => 
                   typeof data.label === 'string' &&

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -13,7 +13,7 @@ import { useThemeStyles } from '../styles';
 import type { Data, ListProperties } from '../types';
 
 /* Renders a modal with a list of selectable items. Takes in props defined in the ListProperties type. */
-const SelectionList = (props: ListProperties & { theme?: 'dark' | 'light' | 'system' }): React.JSX.Element => {
+const SelectionList = (props: ListProperties): React.JSX.Element => {
   const style = useThemeStyles(props.theme ?? 'system');
   const windowWidth = Dimensions.get('window').width;
   const windowHeight = Dimensions.get('window').height;
@@ -87,14 +87,14 @@ const SelectionList = (props: ListProperties & { theme?: 'dark' | 'light' | 'sys
                   borderBottomRightRadius: 0,
                 },
           ]}
-        > 
+        >
           {props.searchable &&
             <TextInput
               placeholder='Search'
               style={[style.searchBox, props.styles.searchBox]}
               placeholderTextColor={style.searchBox.color}
-              onChangeText={(input: string) => 
-                setEntries(props.data.filter((data: Data) => 
+              onChangeText={(input: string) =>
+                setEntries(props.data.filter((data: Data) =>
                   typeof data.label === 'string' &&
                   data.label.toLowerCase().includes(input.toLowerCase())
               ))}
@@ -154,7 +154,7 @@ const SelectionList = (props: ListProperties & { theme?: 'dark' | 'light' | 'sys
                     top: 40,
                     right: 10,
                   }
-              
+
             ]}
           >
             <TouchableOpacity

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,6 +1,21 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, ViewStyle, TextStyle, useColorScheme } from 'react-native';
 
-const light = StyleSheet.create({
+type CommonStyles = {
+  selectorBox: ViewStyle;
+  selectorText: TextStyle;
+  selectedInMultiHighlight: ViewStyle;
+  arrow: TextStyle;
+  clearButton: ViewStyle;
+  clearIcon: TextStyle;
+  searchBox: TextStyle & ViewStyle;
+  list: ViewStyle;
+  text: TextStyle;
+  itemSelected: TextStyle;
+  modalBackground: ViewStyle;
+  item: ViewStyle;
+};
+
+const commonStyles: CommonStyles = {
   selectorBox: {
     display: 'flex',
     flexDirection: 'row',
@@ -10,21 +25,17 @@ const light = StyleSheet.create({
     paddingVertical: 4,
     paddingLeft: 8,
     paddingRight: 24,
-    borderColor: 'black',
     borderWidth: 0.5,
     margin: 5,
-    backgroundColor: 'white',
     overflow: 'hidden',
     flexWrap: 'wrap',
   },
   selectorText: {
     fontSize: 16,
     overflow: 'hidden',
-    color: '#444',
     marginVertical: 4,
   },
   selectedInMultiHighlight: {
-    backgroundColor: '#ccc',
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 12,
@@ -36,16 +47,13 @@ const light = StyleSheet.create({
     position: 'absolute',
     right: 0,
     paddingBottom: 4,
-    color: 'black',
     fontSize: 16,
     fontWeight: 'bold',
   },
   clearButton: {
     width: 40,
     height: 40,
-    backgroundColor: 'white',
     position: 'absolute',
-    borderColor: 'black',
     borderWidth: 0.5,
     borderRadius: 8,
     right: 5,
@@ -53,7 +61,6 @@ const light = StyleSheet.create({
   clearIcon: {
     alignSelf: 'center',
     fontSize: 26,
-    color: 'black',
   },
   searchBox: {
     paddingHorizontal: 8,
@@ -63,117 +70,73 @@ const light = StyleSheet.create({
   },
   list: {
     position: 'absolute',
-    backgroundColor: 'white',
-    borderColor: 'black',
     borderWidth: 0.5,
     overflow: 'hidden',
   },
   text: {
     fontSize: 16,
     paddingLeft: 8,
+  },
+  itemSelected: {
+    fontWeight: 'bold',
+  },
+  modalBackground: {
+    flex: 1,
+  },
+  item: {
+    display: 'flex',
+    justifyContent: 'center',
+    height: 40,
+  },
+};
+
+const lightTheme: Partial<CommonStyles> = {
+  selectorBox: { borderColor: 'black', backgroundColor: 'white' },
+  selectorText: { color: '#444' },
+  selectedInMultiHighlight: { backgroundColor: '#ccc' },
+  arrow: { color: 'black' },
+  clearButton: { backgroundColor: 'white', borderColor: 'black' },
+  clearIcon: { color: 'black' },
+  searchBox: {
+    backgroundColor: 'white',
+    borderColor: 'black',
     color: '#444',
   },
-  itemSelected: {
-    backgroundColor: 'lightblue',
-    fontWeight: 'bold',
-  },
-  modalBackground: {
-    flex: 1,
-  },
-  item: {
-    display: 'flex',
-    justifyContent: 'center',
-    height: 40,
-  },
-});
+  list: { backgroundColor: 'white', borderColor: 'black' },
+  text: { color: '#444' },
+  itemSelected: { backgroundColor: 'lightblue' },
+};
 
-const dark = StyleSheet.create({
-  selectorBox: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    alignContent: 'space-between',
-    paddingVertical: 4,
-    paddingLeft: 8,
-    paddingRight: 24,
-    borderColor: 'black',
-    borderWidth: 0.5,
-    margin: 5,
-    backgroundColor: '#444',
-    overflow: 'hidden',
-    flexWrap: 'wrap',
-  },
-  selectorText: {
-    fontSize: 16,
-    overflow: 'hidden',
-    color: '#ddd',
-    marginVertical: 4,
-  },
-  selectedInMultiHighlight: {
-    backgroundColor: '#222',
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 12,
-    marginRight: 6,
-    marginVertical: 2,
-  },
-  arrow: {
-    width: 28,
-    position: 'absolute',
-    right: 0,
-    paddingBottom: 4,
-    color: 'white',
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
-  clearButton: {
-    width: 40,
-    height: 40,
-    backgroundColor: '#444',
-    position: 'absolute',
-    borderColor: 'black',
-    borderWidth: 0.5,
-    borderRadius: 8,
-    right: 5,
-  },
-  clearIcon: {
-    alignSelf: 'center',
-    fontSize: 26,
-    color: 'white',
-  },
+const darkTheme: Partial<CommonStyles> = {
+  selectorBox: { borderColor: 'black', backgroundColor: '#444' },
+  selectorText: { color: '#ddd' },
+  selectedInMultiHighlight: { backgroundColor: '#222' },
+  arrow: { color: 'white' },
+  clearButton: { backgroundColor: '#444', borderColor: 'black' },
+  clearIcon: { color: 'white' },
   searchBox: {
-    paddingHorizontal: 8,
-    height: 40,
-    borderWidth: 1,
-    margin: 8,
-  },
-  list: {
-    position: 'absolute',
-    backgroundColor: '#444',
-    borderColor: 'black',
-    borderWidth: 0.5,
-    overflow: 'hidden',
-  },
-  text: {
-    fontSize: 16,
-    paddingLeft: 8,
+    backgroundColor: '#333',
+    borderColor: '#555',
     color: '#ddd',
   },
-  itemSelected: {
-    backgroundColor: 'teal',
-    fontWeight: 'bold',
-  },
-  modalBackground: {
-    flex: 1,
-  },
-  item: {
-    display: 'flex',
-    justifyContent: 'center',
-    height: 40,
-  },
-});
+  list: { backgroundColor: '#444', borderColor: 'black' },
+  text: { color: '#ddd' },
+  itemSelected: { backgroundColor: 'teal' },
+};
 
-const styles = [light, dark];
+export const useThemeStyles = (mode: 'dark' | 'light' | 'system') => {
+  const systemTheme = useColorScheme();
+  const selectedTheme = mode === 'system' ? systemTheme : mode;
+  const theme = selectedTheme === 'dark' ? darkTheme : lightTheme;
 
-export default styles;
+  return StyleSheet.create(
+    Object.keys(commonStyles).reduce((acc, key) => {
+      const styleKey = key as keyof CommonStyles;
+      acc[styleKey] = {
+        ...commonStyles[styleKey],
+        ...(theme[styleKey] || {}),
+      };
+      return acc;
+    }, {} as CommonStyles)
+  );
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,6 +36,7 @@ export interface ListProperties {
   searchable: boolean;
   hide: () => void;
   selectorRect: SelectorRect;
+  theme?: 'light' | 'dark' | 'system';
 }
 
 export interface MultiSelectProperties {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,6 +56,7 @@ export interface MultiSelectProperties {
   clearButtonStyle?: ViewStyle;
   clearButtonIconColor?: ColorValue;
   searchBoxStyle?: TextStyle & ViewStyle;
+  theme?: 'light' | 'dark' | 'system';
 }
 
 export interface SelectProperties {
@@ -73,4 +74,5 @@ export interface SelectProperties {
   selectedItemStyle?: TextStyle;
   dropdownArrowColor?: ColorValue;
   searchBoxStyle?: TextStyle & ViewStyle;
+  theme?: 'light' | 'dark' | 'system';
 }


### PR DESCRIPTION
Closes #40

This PR adds a `theme` prop to the `Select` and `MultiSelect` components, allowing explicit control over the theme (`light`, `dark`, or `system`). The components now dynamically adjust placeholder text color in the search box to match the active theme, improving readability. To reduce maintenance overhead, duplicate style definitions in `lightTheme` and `darkTheme` were refactored into a shared `commonStyles` object.

To ensure backwards compatibility, if `theme` is not passed, it defaults to `system`.

### Testing

1. Dynamic Theme Switching:
    - Pass `theme="light"`, `theme="dark"`, and `theme="system"` in both `Select` and `MultiSelect` components.
    - Verify that the components apply the correct theme styling for each mode.

2. System Theme Behavor:
    - Pass `theme="system"` and switch the device’s system theme between light and dark.
    - Confirm that the components dynamically adjust to the system theme.

3. Placeholder Text Color:
    - In both light and dark themes, ensure that the placeholder text in the search box is visible and matches the theme’s text color.

4. Default Behavior:
    - Remove the theme prop and confirm the components fall back to the system theme, as they did previously.