### PR TITLE
Remove Stutter From `SelectionList` When Rendering Above a Selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The clear button for multi select no longer blocks the dropdown list in landscape mode ([#22](https://github.com/rhventures/react-native-dropdown-selector/pull/22)).
 - Setting a default value for multi select now works as intended ([#22](https://github.com/rhventures/react-native-dropdown-selector/pull/22)).
 - The dropdown list now move above the selector box based on current dropdown list height, not max height ([#22](https://github.com/rhventures/react-native-dropdown-selector/pull/22)).
+- The dropdown list now no longer lags behind when trying to render in a new position ([#59](https://github.com/rhventures/react-native-dropdown-selector/pull/59)).
 
 ## [0.1.0] - 2024-06-28
 

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -32,7 +32,6 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
     if (props.display === false)
       return;
     const listBottom = props.selectorRect.y + props.selectorRect.height + listHeight;
-    console.log('props.selectorRect.y:', props.selectorRect.y, ', props.selectorRect.height:', props.selectorRect.height, ', currentListHeight:', listHeight);
     setListTop(
       keyboardHeight > 0 && listBottom > windowHeight - keyboardHeight
         ? windowHeight - keyboardHeight - listHeight - 5

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import {
   Dimensions,
   FlatList,

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -20,23 +20,25 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
   const windowHeight = Dimensions.get('window').height;
   const [keyboardHeight, setKeyboardHeight] = useState<number>(0);
   const [entries, setEntries] = useState<Data[]>(props.data);
-  const [currentListWidth, setCurrentListWidth] = useState<number>(0);
-  const [currentListHeight, setCurrentListHeight] = useState<number>(0);
   const [listTop, setListTop] = useState<number>(0);
   const [listLeft, setListLeft] = useState<number>(0);
   const [buttonTop, setButtonTop] = useState<number>(0);
+  const width = props.styles.list?.width ?? props.selectorRect.width;
+  const listWidth = typeof width === 'string' ? windowWidth*Number(width.slice(0, -1))/100 : width;
+  const itemHeight = (props.styles.text?.fontSize ?? 20) * 2;
+  const listHeight = Math.min(props.listHeight, props.data.length * itemHeight);
 
   useLayoutEffect(() => {
     if (props.display === false)
       return;
-    const listBottom = props.selectorRect.y + props.selectorRect.height + currentListHeight;
-    console.log('props.selectorRect.y: ', props.selectorRect.y, ', props.selectorRect.height: ', props.selectorRect.height, ', currentListHeight: ', currentListHeight);
+    const listBottom = props.selectorRect.y + props.selectorRect.height + listHeight;
+    console.log('props.selectorRect.y:', props.selectorRect.y, ', props.selectorRect.height:', props.selectorRect.height, ', currentListHeight:', listHeight);
     setListTop(
       keyboardHeight > 0 && listBottom > windowHeight - keyboardHeight
-        ? windowHeight - keyboardHeight - currentListHeight - 5
+        ? windowHeight - keyboardHeight - listHeight - 5
         : listBottom < windowHeight
         ? props.selectorRect.y + props.selectorRect.height
-        : props.selectorRect.y - currentListHeight
+        : props.selectorRect.y - listHeight
     );
     setListLeft(
       props.styles.list?.alignSelf === 'center'
@@ -46,7 +48,7 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
           + (typeof props.selectorRect.width === 'string'
             ? Number(props.selectorRect.width.slice(0, -1)) * windowWidth
             : props.selectorRect.width
-            - currentListWidth) / 2
+            - listWidth) / 2
         : props.selectorRect.x
     );
     setButtonTop(
@@ -85,10 +87,6 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
         onPress={props.hide}
       >
         <View
-          onLayout={({ nativeEvent }) => {
-            setCurrentListWidth(nativeEvent.layout.width);
-            setCurrentListHeight(nativeEvent.layout.height);
-          }}
           style={[
             style.list,
             props.styles.list,

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Dimensions,
   FlatList,

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -65,9 +65,8 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
             setCurrentListWidth(nativeEvent.layout.width);
             setCurrentListHeight(nativeEvent.layout.height);
             listBottom = props.selectorRect.y + props.selectorRect.height + nativeEvent.layout.height;
-            const above = listBottom > windowHeight;
-            if (above !== isAbove) {
-              setIsAbove(above);
+            if (listBottom > windowHeight !== isAbove) {
+              setIsAbove(!isAbove);
             } else {
               setPosReady(true);
             }

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import {
   Dimensions,
   FlatList,
@@ -22,7 +22,39 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
   const [entries, setEntries] = useState<Data[]>(props.data);
   const [currentListWidth, setCurrentListWidth] = useState<number>(0);
   const [currentListHeight, setCurrentListHeight] = useState<number>(0);
-  const listBottom = props.selectorRect.y + props.selectorRect.height + currentListHeight;
+  const [listTop, setListTop] = useState<number>(0);
+  const [listLeft, setListLeft] = useState<number>(0);
+  const [buttonTop, setButtonTop] = useState<number>(0);
+
+  useLayoutEffect(() => {
+    if (props.display === false)
+      return;
+    const listBottom = props.selectorRect.y + props.selectorRect.height + currentListHeight;
+    console.log('props.selectorRect.y: ', props.selectorRect.y, ', props.selectorRect.height: ', props.selectorRect.height, ', currentListHeight: ', currentListHeight);
+    setListTop(
+      keyboardHeight > 0 && listBottom > windowHeight - keyboardHeight
+        ? windowHeight - keyboardHeight - currentListHeight - 5
+        : listBottom < windowHeight
+        ? props.selectorRect.y + props.selectorRect.height
+        : props.selectorRect.y - currentListHeight
+    );
+    setListLeft(
+      props.styles.list?.alignSelf === 'center'
+        ? 0
+        : props.styles.list?.width
+        ? props.selectorRect.x
+          + (typeof props.selectorRect.width === 'string'
+            ? Number(props.selectorRect.width.slice(0, -1)) * windowWidth
+            : props.selectorRect.width
+            - currentListWidth) / 2
+        : props.selectorRect.x
+    );
+    setButtonTop(
+      listBottom < windowHeight
+        ? props.selectorRect.y - 40
+        : props.selectorRect.y + props.selectorRect.height
+    );
+  }, [props.display]);
 
   Keyboard.addListener(
     'keyboardDidShow',
@@ -62,22 +94,10 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
             props.styles.list,
             windowHeight > windowWidth
               ? {
-                  left: props.styles.list?.alignSelf === 'center'
-                    ? 0
-                    : props.styles.list?.width
-                    ? props.selectorRect.x
-                      + (typeof props.selectorRect.width === 'string'
-                        ? Number(props.selectorRect.width.slice(0, -1)) * windowWidth
-                        : props.selectorRect.width
-                        - currentListWidth) / 2
-                    : props.selectorRect.x,
+                  left: listLeft,
                   width: props.styles.list?.width ?? props.selectorRect.width,
                   maxHeight: props.listHeight,
-                  top: keyboardHeight > 0 && listBottom > windowHeight - keyboardHeight
-                    ? windowHeight - keyboardHeight - currentListHeight - 5
-                    : listBottom < windowHeight
-                    ? props.selectorRect.y + props.selectorRect.height
-                    : props.selectorRect.y - currentListHeight,
+                  top: listTop,
                 }
               : {
                   height: windowHeight - 40,
@@ -143,9 +163,7 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
               props.styles.clearButton,
               windowHeight > windowWidth
                 ? {
-                    top: listBottom < windowHeight
-                      ? props.selectorRect.y - 40
-                      : props.selectorRect.y + props.selectorRect.height,
+                    top: buttonTop,
                     left: props.selectorRect.x - 40,
                     marginLeft: props.selectorRect.width,
                     opacity: keyboardHeight > 0 ? 0 : 1,
@@ -154,7 +172,6 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
                     top: 40,
                     right: 10,
                   }
-              
             ]}
           >
             <TouchableOpacity

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -26,6 +26,15 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
   const [posReady, setPosReady] = useState<boolean>(false);
   let listBottom = props.selectorRect.y + props.selectorRect.height + currentListHeight;
 
+  const updateListState = (listHeight: number) => {
+    listBottom = props.selectorRect.y + props.selectorRect.height + listHeight;
+    if (listBottom > windowHeight !== isAbove) {
+      setIsAbove(!isAbove);
+    } else {
+      setPosReady(true);
+    }
+  }
+
   Keyboard.addListener(
     'keyboardDidShow',
     () => setKeyboardHeight(Keyboard.metrics()?.height ?? 0)
@@ -64,12 +73,7 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
           onLayout={({ nativeEvent }) => {
             setCurrentListWidth(nativeEvent.layout.width);
             setCurrentListHeight(nativeEvent.layout.height);
-            listBottom = props.selectorRect.y + props.selectorRect.height + nativeEvent.layout.height;
-            if (listBottom > windowHeight !== isAbove) {
-              setIsAbove(!isAbove);
-            } else {
-              setPosReady(true);
-            }
+            updateListState(nativeEvent.layout.height);
           }}
           style={[
             style.list,


### PR DESCRIPTION
This PR solves issue #56 

### Summary

In the existing implementation, calculating the position of a dropdown list is an asynchronous task, meaning that the displayed position won't be accurate until the calculation is complete. Therefore, the dropdown list should be hidden by having `opacity` as 0 by default, and only turn into 1 when the position is finalized.

`onLayout()` triggers every time when the `<Modal>` becomes visible, so it first quickly determine if the dropdown should be rendered above or below the selector. If the dropdown should flip, then the `opacity` stays 0, otherwise it will become 1. If the dropdown needs to flip, then the dropdown's style will be guaranteed to change, which will trigger `onLayout()` again and `opacity` will ultimately become 1. This effectively removes the stutter described from #56.

### Testing

Manual UI testing was performed to ensure there was no unintended behavior:
- Opening and closing every MultiSelect/Select with adequate space below them
- Opening and closing every MultiSelect/Select with no space below them, causing SelectionList to render above the Selector box instead
- Opening every MultiSelect/Select with adequate space below them after closing them at a different scroll location

### Potential Issues

Since `opacity` begins with 0 before the style is determined, the component may appear to be slower to show the dropdown lists compared to the one from main branch. This problem appears to be unavoidable, unless there is another way to resolve #56 that I am not aware of.