### PR TITLE
Add `onRemove` Prop for `MultiSelect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Content inside the dropdown list will now be cut off if it extends beyond the dropdown list boundaries ([#22](https://github.com/rhventures/react-native-dropdown-selector/pull/22)).
 - Technical detailes from README is now moved to GitHub Wiki ([#23](https://github.com/rhventures/react-native-dropdown-selector/pull/23)).
 - Old screenshots of the example app are replaced by new ones ([#23](https://github.com/rhventures/react-native-dropdown-selector/pull/23)).
-- The `onRemove` prop is added to the selector components to be triggered when items are removed, rather than triggering `onSelect` ([#60](https://github.com/rhventures/react-native-dropdown-selector/pull/60))
+- The `onRemove` prop is added to the selector components to be triggered when items are removed, rather than triggering `onSelect` ([#60](https://github.com/rhventures/react-native-dropdown-selector/pull/60)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Content inside the dropdown list will now be cut off if it extends beyond the dropdown list boundaries ([#22](https://github.com/rhventures/react-native-dropdown-selector/pull/22)).
 - Technical detailes from README is now moved to GitHub Wiki ([#23](https://github.com/rhventures/react-native-dropdown-selector/pull/23)).
 - Old screenshots of the example app are replaced by new ones ([#23](https://github.com/rhventures/react-native-dropdown-selector/pull/23)).
+- The `onRemove` prop is added to the selector components to be triggered when items are removed, rather than triggering `onSelect` ([#60](https://github.com/rhventures/react-native-dropdown-selector/pull/60))
 
 ### Removed
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -25,11 +25,18 @@ const themes: Data[] = [
 ];
 
 function App(): React.JSX.Element {
+  const [item, setItem] = React.useState<string | JSX.Element>('');
   const [selected, setSelected] = React.useState<string | JSX.Element>('');
   const [removed, setRemoved] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
   const [searchable, setSearchable] = React.useState(false);
   const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
+  const onSimpleDataSelect = (datum: Data) =>
+    setItem(datum.label);
+  const onSimpleMultiDataSelect = (data: Data[]) =>
+    setItem(data.map((datum: Data) =>
+      datum.label
+    ).join(", "));
   const onDataSelect = (datum: Data) => {
     setSelected(datum.label);
     setRemoved('');
@@ -52,16 +59,12 @@ function App(): React.JSX.Element {
         <View style={{ height: 40 }} />
         <Select
           data={data}
-          onSelect={onDataSelect}
+          onSelect={onSimpleDataSelect}
           disabled={disabled}
           searchable={searchable}
           theme={theme}
         />
-        <Text>
-          Selected: {(selected || 'None')+'\n'}
-          Removed: {(removed || 'None')+'\n'}
-          (scroll down to see more examples)
-        </Text>
+        <Text>Selected: {item || 'None'} (scroll down)</Text>
         <View style={{ height: 500 }} />
         <Text
           style={{
@@ -74,7 +77,7 @@ function App(): React.JSX.Element {
         </Text>
         <Select
           data={data}
-          onSelect={onDataSelect}
+          onSelect={onSimpleDataSelect}
           disabled={disabled}
           searchable={searchable}
           placeholderText="Select an item"
@@ -86,14 +89,20 @@ function App(): React.JSX.Element {
         />
         <MultiSelect
           data={data}
-          onSelect={onMultiDataSelect}
+          onSelect={onSimpleMultiDataSelect}
           onRemove={onDataRemove}
           disabled={disabled}
           searchable={searchable}
           theme={theme}
         />
         <View style={{ height: 400 }}/>
-        <Text>Single Selects:</Text>
+        <Text>
+          The selected and removed items from the next 2 rows of selectors will be displayed here.
+          {'\n\n'}
+          Selected: {(selected || 'None')+'\n'}
+          Removed: {(removed || 'None')+'\n\n'}
+          Single Selects:
+        </Text>
         <View style={{ flexDirection: 'row', height: 100 }}>
           <View style={{ flex: 1 }}>
             <Select
@@ -197,7 +206,7 @@ function App(): React.JSX.Element {
         <Text>Styled Single Select:</Text>
         <Select
           data={data}
-          onSelect={onDataSelect}
+          onSelect={onSimpleDataSelect}
           disabled={disabled}
           searchable={searchable}
           defaultValue={data[0]}
@@ -276,8 +285,7 @@ function App(): React.JSX.Element {
         <Text>Styled Multi Select:</Text>
         <MultiSelect
           data={data}
-          onSelect={onMultiDataSelect}
-          onRemove={onDataRemove}
+          onSelect={onSimpleMultiDataSelect}
           disabled={disabled}
           searchable={searchable}
           defaultValue={data}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -24,6 +24,8 @@ function App(): React.JSX.Element {
   const [searchable, setSearchable] = React.useState(false);
   const onDataSelect = (datum: Data) =>
     setItem(datum.label);
+  const onDataRemove = (datum: Data) =>
+    console.log('removed', datum.label);
   const onMultiDataSelect = (data: Data[]) =>
     setItem(data.map((datum: Data) =>
       datum.label
@@ -65,6 +67,7 @@ function App(): React.JSX.Element {
         <MultiSelect
           data={data}
           onSelect={onMultiDataSelect}
+          onRemove={onDataRemove}
           disabled={disabled}
           searchable={searchable}
         />

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -90,7 +90,6 @@ function App(): React.JSX.Element {
         <MultiSelect
           data={data}
           onSelect={onSimpleMultiDataSelect}
-          onRemove={onDataRemove}
           disabled={disabled}
           searchable={searchable}
           theme={theme}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -19,17 +19,22 @@ const options: Data[] = [
 ];
 
 function App(): React.JSX.Element {
-  const [item, setItem] = React.useState<string | JSX.Element>('');
+  const [selected, setSelected] = React.useState<string | JSX.Element>('');
+  const [removed, setRemoved] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
   const [searchable, setSearchable] = React.useState(false);
-  const onDataSelect = (datum: Data) =>
-    setItem(datum.label);
-  const onDataRemove = (datum: Data) =>
-    console.log('removed', datum.label);
-  const onMultiDataSelect = (data: Data[]) =>
-    setItem(data.map((datum: Data) =>
-      datum.label
-    ).join(", "));
+  const onDataSelect = (datum: Data) => {
+    setSelected(datum.label);
+    setRemoved('');
+  };
+  const onDataRemove = (datum: Data) => {
+    setSelected((selected as string).split(', ').filter(item => item !== datum.label).join(', '));
+    setRemoved(datum.label);
+  };
+  const onMultiDataSelect = (data: Data[]) => {
+    setSelected(data.map(datum => datum.label).join(", "));
+    setRemoved('');
+  };
 
   return (
     <>
@@ -42,7 +47,11 @@ function App(): React.JSX.Element {
           disabled={disabled}
           searchable={searchable}
         />
-        <Text>Selected: {item || 'None'} (scroll down)</Text>
+        <Text>
+          Selected: {(selected || 'None')+'\n'}
+          Removed: {(removed || 'None')+'\n'}
+          (scroll down to see more examples)
+        </Text>
         <View style={{ height: 500 }} />
         <Text
           style={{
@@ -106,6 +115,7 @@ function App(): React.JSX.Element {
               <MultiSelect
                 data={data}
                 onSelect={onMultiDataSelect}
+                onRemove={onDataRemove}
                 disabled={disabled}
                 searchable={searchable}
               />
@@ -114,6 +124,7 @@ function App(): React.JSX.Element {
               <MultiSelect
                 data={data}
                 onSelect={onMultiDataSelect}
+                onRemove={onDataRemove}
                 disabled={disabled}
                 searchable={searchable}
               />
@@ -122,6 +133,7 @@ function App(): React.JSX.Element {
               <MultiSelect
                 data={data}
                 onSelect={onMultiDataSelect}
+                onRemove={onDataRemove}
                 disabled={disabled}
                 searchable={searchable}
               />
@@ -135,12 +147,15 @@ function App(): React.JSX.Element {
             onSelect={(data: Data[]) => {
               if (data.includes(options[0])) {
                 setDisabled(true);
-              } else {
-                setDisabled(false);
               }
               if (data.includes(options[1])) {
                 setSearchable(true);
-              } else {
+              }
+            }}
+            onRemove={(data: Data) => {
+              if (data === options[0]) {
+                setDisabled(false);
+              } else if (data === options[1]) {
                 setSearchable(false);
               }
             }}
@@ -231,6 +246,7 @@ function App(): React.JSX.Element {
         <MultiSelect
           data={data}
           onSelect={onMultiDataSelect}
+          onRemove={onDataRemove}
           disabled={disabled}
           searchable={searchable}
           defaultValue={data}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -26,8 +26,6 @@ const themes: Data[] = [
 
 function App(): React.JSX.Element {
   const [item, setItem] = React.useState<string | JSX.Element>('');
-  const [selected, setSelected] = React.useState<string | JSX.Element>('');
-  const [removed, setRemoved] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
   const [searchable, setSearchable] = React.useState(false);
   const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
@@ -37,17 +35,14 @@ function App(): React.JSX.Element {
     setItem(data.map((datum: Data) =>
       datum.label
     ).join(", "));
-  const onDataSelect = (datum: Data) => {
-    setSelected(datum.label);
-    setRemoved('');
+  const onDataSelect = (id: number) => (datum: Data) => {
+    console.log(`selector ${id}: ${datum.label} selected`);
   };
-  const onDataRemove = (datum: Data) => {
-    setSelected((selected as string).split(', ').filter(item => item !== datum.label).join(', '));
-    setRemoved(datum.label);
+  const onDataRemove = (id: number) => (datum: Data) => {
+    console.log(`selector ${id}: ${datum.label} removed`);
   };
-  const onMultiDataSelect = (data: Data[]) => {
-    setSelected(data.map(datum => datum.label).join(", "));
-    setRemoved('');
+  const onMultiDataSelect = (id: number) => (data: Data[]) => {
+    console.log(`selector ${id}: currently contains ${data.map(datum => datum.label).join(", ")}.`);
   };
   const onThemeSelect = (datum: Data) =>
     setTheme(datum.label as 'light' | 'dark' | 'system');
@@ -95,18 +90,12 @@ function App(): React.JSX.Element {
           theme={theme}
         />
         <View style={{ height: 400 }}/>
-        <Text>
-          The selected and removed items from the next 2 rows of selectors will be displayed here.
-          {'\n\n'}
-          Selected: {(selected || 'None')+'\n'}
-          Removed: {(removed || 'None')+'\n\n'}
-          Single Selects:
-        </Text>
+        <Text>Single Selects:</Text>
         <View style={{ flexDirection: 'row', height: 100 }}>
           <View style={{ flex: 1 }}>
             <Select
               data={data}
-              onSelect={onDataSelect}
+              onSelect={onDataSelect(1)}
               disabled={disabled}
               searchable={searchable}
               theme={theme}
@@ -115,7 +104,7 @@ function App(): React.JSX.Element {
           <View style={{ flex: 1 }}>
             <Select
               data={data}
-              onSelect={onDataSelect}
+              onSelect={onDataSelect(2)}
               disabled={disabled}
               searchable={searchable}
               theme={theme}
@@ -124,7 +113,7 @@ function App(): React.JSX.Element {
           <View style={{ flex: 1 }}>
             <Select
               data={data}
-              onSelect={onDataSelect}
+              onSelect={onDataSelect(3)}
               disabled={disabled}
               searchable={searchable}
               theme={theme}
@@ -137,8 +126,8 @@ function App(): React.JSX.Element {
             <View style={{ flex: 1 }}>
               <MultiSelect
                 data={data}
-                onSelect={onMultiDataSelect}
-                onRemove={onDataRemove}
+                onSelect={onMultiDataSelect(4)}
+                onRemove={onDataRemove(4)}
                 disabled={disabled}
                 searchable={searchable}
                 theme={theme}
@@ -147,8 +136,8 @@ function App(): React.JSX.Element {
             <View style={{ flex: 1 }}>
               <MultiSelect
                 data={data}
-                onSelect={onMultiDataSelect}
-                onRemove={onDataRemove}
+                onSelect={onMultiDataSelect(5)}
+                onRemove={onDataRemove(5)}
                 disabled={disabled}
                 searchable={searchable}
                 theme={theme}
@@ -157,8 +146,8 @@ function App(): React.JSX.Element {
             <View style={{ flex: 1 }}>
               <MultiSelect
                 data={data}
-                onSelect={onMultiDataSelect}
-                onRemove={onDataRemove}
+                onSelect={onMultiDataSelect(6)}
+                onRemove={onDataRemove(6)}
                 disabled={disabled}
                 searchable={searchable}
                 theme={theme}

--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -19,10 +19,6 @@ const MultiSelect = (props: MultiSelectProperties): React.JSX.Element => {
     props.data.filter((d: Data) =>
     props.defaultValue?.includes(d))
   );
-  const selectItem = (items: Data[]) => {
-    setSelected(items);
-    props.onSelect(items);
-  };
   const updatePriorities = (data: Data[]) => [
     ...data.filter((d: Data) => d.priority),
     ...data.filter((d: Data) => !d.priority),
@@ -99,8 +95,10 @@ const MultiSelect = (props: MultiSelectProperties): React.JSX.Element => {
         }}
         data={updatePriorities(props.data)}
         type="multi"
-        onSelect={selectItem}
+        onSelect={props.onSelect}
+        onRemove={props.onRemove}
         selected={selected}
+        setSelected={setSelected}
         clearSelected={() => setSelected([])}
         listHeight={props.listHeight ?? 200}
         display={listDisplay}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -20,10 +20,6 @@ const Select = (props: SelectProperties): React.JSX.Element => {
       ? props.defaultValue
       : {label: props.placeholderText ?? 'Click me'}
   );
-  const selectItem = (item: Data) => {
-    setSelected(item);
-    props.onSelect(item);
-  };
   const updatePriorities = (data: Data[]) => [
     ...data.filter((d: Data) => d.priority),
     ...data.filter((d: Data) => !d.priority),
@@ -75,8 +71,9 @@ const Select = (props: SelectProperties): React.JSX.Element => {
         }}
         data={updatePriorities(props.data)}
         type="single"
-        onSelect={selectItem}
+        onSelect={props.onSelect}
         selected={selected}
+        setSelected={setSelected}
         listHeight={props.listHeight ?? 200}
         display={listDisplay}
         searchable={!!props.searchable}

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -116,8 +116,7 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
                     let newSelected: Data[];
                     if (selected.includes(item)) {
                       newSelected = selected.filter((d: Data) => d !== item);
-                      if (props.onRemove !== undefined)
-                        props.onRemove(item);
+                      props.onRemove?.(item);
                     } else {
                       newSelected = [...selected, item];
                       (props.onSelect as (d: Data[]) => void)(newSelected);

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -108,14 +108,21 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
               <TouchableOpacity
                 onPress={() => {
                   if (props.type === 'single') {
+                    (props.setSelected as (d: Data) => void)(item);
                     (props.onSelect as (d: Data) => void)(item);
                     props.hide();
                   } else {
-                    const selected = props.selected as Data[],
-                      newSelected = selected.includes(item)
-                        ? selected.filter((d: Data) => d !== item)
-                        : [...selected, item];
-                    (props.onSelect as (d: Data[]) => void)(newSelected);
+                    const selected = props.selected as Data[];
+                    let newSelected: Data[];
+                    if (selected.includes(item)) {
+                      newSelected = selected.filter((d: Data) => d !== item);
+                      if (props.onRemove !== undefined)
+                        props.onRemove(item);
+                    } else {
+                      newSelected = [...selected, item];
+                      (props.onSelect as (d: Data[]) => void)(newSelected);
+                    }
+                    (props.setSelected as (d: Data[]) => void)(newSelected);
                   }
                 }}
                 style={[

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -117,11 +117,12 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
                     if (selected.includes(item)) {
                       newSelected = selected.filter((d: Data) => d !== item);
                       props.onRemove?.(item);
+                      (props.setSelected as (d: Data[]) => void)(newSelected);
                     } else {
                       newSelected = [...selected, item];
+                      (props.setSelected as (d: Data[]) => void)(newSelected);
                       (props.onSelect as (d: Data[]) => void)(newSelected);
                     }
-                    (props.setSelected as (d: Data[]) => void)(newSelected);
                   }
                 }}
                 style={[

--- a/src/components/SelectionList.tsx
+++ b/src/components/SelectionList.tsx
@@ -116,8 +116,8 @@ const SelectionList = (props: ListProperties): React.JSX.Element => {
                     let newSelected: Data[];
                     if (selected.includes(item)) {
                       newSelected = selected.filter((d: Data) => d !== item);
-                      props.onRemove?.(item);
                       (props.setSelected as (d: Data[]) => void)(newSelected);
+                      props.onRemove?.(item);
                     } else {
                       newSelected = [...selected, item];
                       (props.setSelected as (d: Data[]) => void)(newSelected);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,7 +29,9 @@ export interface ListProperties {
   data: Data[];
   type: 'single' | 'multi';
   onSelect: ((e: Data) => void) | ((e: Data[]) => void);
+  onRemove?: (e: Data) => void;
   selected: Data[] | Data;
+  setSelected: ((e: Data) => void) | ((e: Data[]) => void);
   clearSelected?: () => void;
   listHeight: number;
   display: boolean;
@@ -41,6 +43,7 @@ export interface ListProperties {
 export interface MultiSelectProperties {
   data: Data[];
   onSelect: (e: Data[]) => void;
+  onRemove?: (e: Data) => void;
   defaultValue?: Data[];
   disabled?: boolean;
   listHeight?: number;


### PR DESCRIPTION
This PR addresses #58

### Summary

The current `onSelect` prop implementation in the `main` branch would trigger every time that an item is either selected or deselected. This may cause confusion for developers, so this PR divides the `onSelect` prop into `onSelect` and `onRemove`.

### Testing

Manual UI testing was performed to ensure there was no unintended behavior:
- Selecting items in `Select`/`MultiSelect` to ensure that `onSelect` still triggers
- Deselecting items in `Select`/`MultiSelect` to ensure that `onRemove` triggers