### PR TITLE
Add Dynamic Styling for Example App Background and Text

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text, View, SafeAreaView } from 'react-native';
 import { MultiSelect, Select, type Data } from '@rose-hulman/react-native-dropdown-selector';
+import { useThemeStyles } from './styles';
 
 const data: Data[] = [
   { label: 'Item 1' },
@@ -25,22 +26,33 @@ const themes: Data[] = [
 ];
 
 function App(): React.JSX.Element {
+  const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
+  const onThemeSelect = (datum: Data) => {
+    setTheme(datum.label as 'light' | 'dark' | 'system');
+  }
+
+  return (
+    <Content
+      onThemeSelect={onThemeSelect}
+      theme={theme}
+    />);
+}
+
+const Content = ({ onThemeSelect, theme }: ContentProperties): React.JSX.Element => {
   const [item, setItem] = React.useState<string | JSX.Element>('');
   const [disabled, setDisabled] = React.useState(false);
   const [searchable, setSearchable] = React.useState(false);
-  const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
+  const style = useThemeStyles(theme);
+
   const onDataSelect = (datum: Data) =>
     setItem(datum.label);
   const onMultiDataSelect = (data: Data[]) =>
     setItem(data.map((datum: Data) =>
       datum.label
     ).join(", "));
-  const onThemeSelect = (datum: Data) =>
-    setTheme(datum.label as 'light' | 'dark' | 'system');
 
   return (
-    <>
-      <View style={{ height: 40 }} />
+    <SafeAreaView style={style.background}>
       <ScrollView style={{ paddingHorizontal: 8 }}>
         <View style={{ height: 40 }} />
         <Select
@@ -50,13 +62,17 @@ function App(): React.JSX.Element {
           searchable={searchable}
           theme={theme}
         />
-        <Text>Selected: {item || 'None'} (scroll down)</Text>
+        <Text style={style.text}>
+          Selected: {item || 'None'} (scroll down)
+        </Text>
         <View style={{ height: 500 }} />
         <Text
-          style={{
+          style={[
+            style.text,
+            {
             alignSelf: 'center',
             width: 350,
-          }}
+          }]}
         >
           The dropdown menu will display above the input box when there
           isn&apos;t enough space below
@@ -81,7 +97,7 @@ function App(): React.JSX.Element {
           theme={theme}
         />
         <View style={{ height: 400 }}/>
-        <Text>Single Selects:</Text>
+        <Text style={style.text}>Single Selects:</Text>
         <View style={{ flexDirection: 'row', height: 100 }}>
           <View style={{ flex: 1 }}>
             <Select
@@ -111,7 +127,7 @@ function App(): React.JSX.Element {
             />
           </View>
         </View>
-        <Text>Multi Selects:</Text>
+        <Text style={style.text}>Multi Selects:</Text>
         <View style={{ height: 350 }}>
           <View style={{ flexDirection: 'row' }}>
             <View style={{ flex: 1 }}>
@@ -142,7 +158,7 @@ function App(): React.JSX.Element {
               />
             </View>
           </View>
-          <Text style={{ textAlign: 'center', height: 100 }}>
+          <Text style={[style.text, { textAlign: 'center', height: 100 }]}>
             Select more than one item and see me move!
           </Text>
           <MultiSelect
@@ -172,11 +188,11 @@ function App(): React.JSX.Element {
             placeholderText={`Select a theme`}
             theme={theme}
           />
-          <Text style={{ textAlign: 'center'}}>
+          <Text style={[style.text, { textAlign: 'center'}]}>
             Select a theme to see all the dropdowns change! Current theme is "{theme}"
           </Text>
         </View>
-        <Text>Styled Single Select:</Text>
+        <Text style={style.text}>Styled Single Select:</Text>
         <Select
           data={data}
           onSelect={onDataSelect}
@@ -255,7 +271,7 @@ function App(): React.JSX.Element {
           }}
         />
         <View style={{height: 50}} />
-        <Text>Styled Multi Select:</Text>
+        <Text style={style.text}>Styled Multi Select:</Text>
         <MultiSelect
           data={data}
           onSelect={onMultiDataSelect}
@@ -355,8 +371,13 @@ function App(): React.JSX.Element {
         />
         <View style={{ height: 700 }} />
       </ScrollView>
-    </>
+    </SafeAreaView>
   );
+}
+
+interface ContentProperties {
+  onThemeSelect: (e: Data) => void;
+  theme: 'light' | 'dark' | 'system';
 }
 
 export default App;

--- a/example/styles.ts
+++ b/example/styles.ts
@@ -1,0 +1,39 @@
+import { StyleSheet, ViewStyle, TextStyle, useColorScheme } from 'react-native';
+
+type CommonStyles = {
+  background: ViewStyle;
+  text: TextStyle;
+};
+
+const commonStyles: CommonStyles = {
+  background: {},
+  text: {},
+};
+
+const lightTheme: Partial<CommonStyles> = {
+  background: { backgroundColor: '#fafafa' },
+  text: { color: '#737373' },
+};
+
+const darkTheme: Partial<CommonStyles> = {
+  background: { backgroundColor: '#2e2e2e' },
+  text: { color: '#c1c1c1' },
+};
+
+// Original implementation in ../src/styles.ts
+export const useThemeStyles = (mode: 'dark' | 'light' | 'system') => {
+  const systemTheme = useColorScheme();
+  const selectedTheme = mode === 'system' ? systemTheme : mode;
+  const theme = selectedTheme === 'dark' ? darkTheme : lightTheme;
+
+  return StyleSheet.create(
+    Object.keys(commonStyles).reduce((acc, key) => {
+      const styleKey = key as keyof CommonStyles;
+      acc[styleKey] = {
+        ...commonStyles[styleKey],
+        ...(theme[styleKey] || {}),
+      };
+      return acc;
+    }, {} as CommonStyles)
+  );
+};


### PR DESCRIPTION
## Summary
This pull request adds dynamic `light`, `dark`, and `system` styling modes for the example app's background and text. The style responds to the devices dark mode setting if `system` styling mode is chosen; otherwise, the style responds to if `light` or `dark` mode has been selected.

Because the example app now has a `Select` component to toggle a similar setting for all `Select` and `MultiSelect` components, I tied the background and text styles to follow that same `Select` component.

## Testing
These changes can be visually tested by toggling the test device's dark mode, or by changing the style `Select` component in the example app.

I tested these changes in React Native `0.74.1` on both Android and iOS.

## Relations
This pull request addresses #63.