### PR TITLE
Fix React Peer Dependency Bounds for Compatibility with React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@rose-hulman/react-native-dropdown-selector",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.9",
@@ -22,8 +22,8 @@
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-native": "^0.71.19"
+        "react": ">=18.2.0 <20.0.0",
+        "react-native": ">=0.71.0 <0.81.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6115,21 +6115,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "peer": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/rhventures/react-native-dropdown-selector#readme",
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-native": "^0.71.19"
+    "react": ">=18.2.0 <20.0.0",
+    "react-native": ">=0.71.0 <0.81.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.9",


### PR DESCRIPTION
This PR updates the peerDependencies in the package to resolve issues when installing the component in projects using React 19. Without this change, users encounter peer dependency conflicts when their projects use React versions ≥19.0.0.


Changes Made:
Updated peerDependencies for react to allow versions >=18.2.0 <20.0.0
Optionally: Updated react-native peer dependency range to support >=0.71.0 <0.81.0 if relevant

Why This Matters:
React 19 is now widely used, and this change ensures that the package installs cleanly without requiring --force or --legacy-peer-deps.