### PR TITLE
Update README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Many internal calculations have been retooled to use internal fields for easier readability ([#111](https://github.com/rhventures/react-native-dropdown-selector/pull/111)).
+- Update the icons of dropdown arrow and clear button to use SVGs instead of font icons ([#114](https://github.com/rhventures/react-native-dropdown-selector/pull/114)).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ A custom React Native component for dropdown lists that emulates some functional
 npm i @rose-hulman/react-native-dropdown-selector
 ```
 
+Since `react-native-svg` is a peer dependency, you will need to install it along with the component if you do not already have it in your project.
+
+```bash
+npm i react-native-svg
+```
+
 ## How Do I Use It?
 
 There are 2 components available for use:


### PR DESCRIPTION
This PR aims to update `README` to include the requirement of installing `react-native-svg` while using the component as it is a peer dependency. Also update `CHANGELOG` and link it to PR #[114](https://github.com/rhventures/react-native-dropdown-selector/pull/114).